### PR TITLE
fix: add babel plugin to transform private methods

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": [["babel-preset-gatsby-package", { "browser": true }]]
+  "presets": [["babel-preset-gatsby-package", { "browser": true }]],
+  "plugins": [["@babel/plugin-transform-private-methods", { "loose": true }]]
 }


### PR DESCRIPTION
Fixes the following issue when using the published npm version:

```
Module build failed (from ./node_modules/gatsby/dist/utils/babel-loader.js):
SyntaxError: /Users/ulrich.herzkamp/projects/blog/node_modules/gatsby-plugin-google-gtag-cookieconsent/node_modules/minimatch/dist/cjs/ast.js: Class private methods are not
enabled. Please add `@babel/plugin-transform-private-methods` to your configuration.
```