### PR TITLE
feat: add simple configruation flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,14 @@ Add this to your `gatsby-config.js`
       resolve: `gatsby-plugin-google-gtag-cookieconsent`,
       options: {
         cookieConsentConfig: { ... },
-        enableForAllEnvironments: true,
+        enableForAllEnvironments: true, // deprecated
+        enabled: true,
         googleGtagPluginConfig: { ... },
       },
     },
 ```
 
-You might want to set `enableForAllEnvironments` to `false` to only enable the plugin for production builds.
+You can use the enabled flag to disable the plugin in development mode. An example can be found in [examples/gatsby-config.js](./examples/gatsby-config.js) folder.
 
 In order to save space in your config file, I would recommend to move the extensive cookie consent config into a separate file, e.g. `cookie-consent-config`: 
 

--- a/examples/gatsby-config.js
+++ b/examples/gatsby-config.js
@@ -1,0 +1,29 @@
+const { cookieConsentConfig } = require("./cookie-consent-config");
+
+module.exports = {
+  plugins: [
+    {
+      resolve: `gatsby-plugin-google-gtag-cookieconsent`,
+      options: {
+        cookieConsentConfig: cookieConsentConfig,
+        enabled: process.env.NODE_ENV === 'production', // replace this with any condition you need
+        googleGtagPluginConfig: {
+          trackingIds: [
+            "GA_ID", // Google Analytics / GA
+          ],
+          gtagConfig: {
+            optimize_id: "OPT_CONTAINER_ID",
+            anonymize_ip: true,
+            cookie_expires: 0,
+          },
+          pluginConfig: {
+            head: false,
+            respectDNT: true,
+            exclude: ["/preview/**"],
+            origin: "https://www.googletagmanager.com",
+          },
+        },
+      },
+    },
+  ].filter(Boolean),
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,7 @@
 export const isPluginDisabled = (pluginOptions) => {
+    if (pluginOptions.enabled !== undefined) {
+        return !pluginOptions.enabled;
+    }
+    // keep for backwards compatibility
     return !pluginOptions.enableForAllEnvironments && process.env.NODE_ENV !== `production` && process.env.NODE_ENV !== `test`
 }


### PR DESCRIPTION
The condition if the plugin should be shown or not, is currently assuming that the site is run with `NODE_ENV===production` or forces to use `enableForAllEnvironments: true` which also enables locally which might not be desired.

Idea here is to have a single simple `enabled` flag that puts the condition entirely in the hands of the plugin consuming site configuration.